### PR TITLE
EX6: Add C4 diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,7 @@ Run `docker compose -f docker-compose-dev.yaml up --build`.
 The app can then be accessed at `http://localhost:8080/`. 
 
 Changes made to your local code files should be reflected in the app without needing to rebuild the image.
+
+## Documentation
+
+See [here](docs/docs.md) for documentation.

--- a/docs/C4Component.md
+++ b/docs/C4Component.md
@@ -1,0 +1,26 @@
+```mermaid
+C4Component
+    Container(flask, "Flask Web Server")
+
+    Container_Boundary(todoAppCode, "To-Do Application Code") {
+        Component(htmlTemplates, "HTML Templates")
+        Component(routes, "Webserver Routes", "app.py")
+        Component(dataClasses, "Data Classes")
+        Component(trelloClient, "Trello Client", "trello_items.py")
+    }
+
+    System_Ext(trelloApi, "Trello API")
+
+    Rel(flask, routes, "Passes request to")
+
+    Rel(htmlTemplates, routes, "")
+    Rel(dataClasses, routes, "")
+    Rel(dataClasses, trelloClient, "")
+    Rel(routes, trelloClient, "")
+
+    Rel(trelloClient, trelloApi, "Talks via HTTP")
+
+    UpdateLayoutConfig($c4ShapeInRow="3")
+    UpdateRelStyle(flask, routes, $offsetX="-175", $offsetY="-50")
+    UpdateRelStyle(trelloClient, trelloApi, $offsetX="85", $offsetY="-150")
+```

--- a/docs/C4Container.md
+++ b/docs/C4Container.md
@@ -1,0 +1,19 @@
+```mermaid
+C4Container
+    System_Ext(browser, "Web Browser")
+
+    Boundary(todoApp, "To-Do Application") {
+        Container(flask, "Flask Web Server")
+        Container(todoAppCode, "To-Do Application Code", "Python App")
+    }
+
+    System_Ext(trelloApi, "Trello API")
+
+    Rel(browser, flask, "Talks via HTTP")
+    Rel(flask, todoAppCode, "Passes request to")
+    Rel(todoAppCode, trelloApi, "Talks via HTTP")
+
+    UpdateRelStyle(browser, flask, $offsetX="-5", $offsetY="-50")
+    UpdateRelStyle(flask, todoAppCode, $offsetX="-48", $offsetY="-20")
+    UpdateRelStyle(todoAppCode, trelloApi, $offsetX="0", $offsetY="-50")
+```

--- a/docs/C4Context.md
+++ b/docs/C4Context.md
@@ -1,0 +1,16 @@
+```mermaid
+C4Context
+    Person(user, "User")
+    System_Ext(browser, "Web Browser")
+    System(todoApp, "To-Do Application")
+    System_Ext(trelloApi, "Trello API")
+
+    Rel(user, browser, "Operates")
+    Rel(browser, todoApp, "Talks via HTTP")
+    Rel(todoApp, trelloApi, "Talks via HTTP")
+
+    UpdateLayoutConfig($c4ShapeInRow="1")
+    UpdateRelStyle(user, browser, $offsetX="5", $offsetY="0")
+    UpdateRelStyle(browser, todoApp, $offsetX="5", $offsetY="0")
+    UpdateRelStyle(todoApp, trelloApi, $offsetX="5", $offsetY="0")
+```

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1,0 +1,8 @@
+# C4 Diagrams
+
+See the following architecture diagrams, following the [C4 model](https://c4model.com/):
+- [System Context](C4Context.md)
+- [Container](C4Container.md)
+- [Component](C4Component.md)
+
+These diagrams are made using [Mermaid](https://mermaid.js.org/syntax/c4.html). To view the diagrams in your IDE, install a plugin such as Markdown Preview Mermaid Support for VSCode. Otherwise, you can view the diagrams by pasting the Mermaid code [here](https://mermaid.live/).


### PR DESCRIPTION
> The exported diagrams are checked into source control

I've skipped this step from the submission checklist and added instructions to install an IDE plugin to view the diagrams instead - I prefer this as it means there are fewer steps needed to update the diagrams. But can check exported diagrams in too if needed 🙂 